### PR TITLE
[FEAT] Theme API 구현

### DIFF
--- a/src/main/java/com/nextroom/oescape/controller/ThemeController.java
+++ b/src/main/java/com/nextroom/oescape/controller/ThemeController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.nextroom.oescape.domain.Shop;
 import com.nextroom.oescape.dto.BaseResponse;
 import com.nextroom.oescape.dto.DataResponse;
 import com.nextroom.oescape.dto.ThemeDto;
@@ -27,26 +28,26 @@ public class ThemeController {
     @PostMapping
     public ResponseEntity<BaseResponse> addTheme(
         @RequestBody ThemeDto.AddThemeRequest request) {
-        themeService.addTheme(request);
+        themeService.addTheme(new Shop(), request);
         return ResponseEntity.ok(new BaseResponse(OK));
     }
 
     @GetMapping
     public ResponseEntity<BaseResponse> getThemeList() {
-        return ResponseEntity.ok(new DataResponse<>(OK, themeService.getThemeList()));
+        return ResponseEntity.ok(new DataResponse<>(OK, themeService.getThemeList(new Shop())));
     }
 
     @PutMapping
     public ResponseEntity<BaseResponse> editTheme(
         @RequestBody ThemeDto.EditThemeRequest request) {
-        themeService.editTheme(request);
+        themeService.editTheme(new Shop(), request);
         return ResponseEntity.ok(new BaseResponse(OK));
     }
 
     @DeleteMapping
     public ResponseEntity<BaseResponse> removeTheme(
         @RequestBody ThemeDto.RemoveRequest request) {
-        themeService.removeTheme(request);
+        themeService.removeTheme(new Shop(), request);
         return ResponseEntity.ok(new BaseResponse(OK));
     }
 }

--- a/src/main/java/com/nextroom/oescape/domain/Theme.java
+++ b/src/main/java/com/nextroom/oescape/domain/Theme.java
@@ -3,6 +3,8 @@ package com.nextroom.oescape.domain;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.nextroom.oescape.dto.ThemeDto;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -33,4 +35,9 @@ public class Theme {
     private Integer timeLimit;
     @OneToMany(mappedBy = "theme", cascade = CascadeType.ALL)
     private List<Hint> hints = new ArrayList<>();
+
+    public void update(ThemeDto.EditThemeRequest request) {
+        this.title = request.getTitle();
+        this.timeLimit = request.getTimeLimit();
+    }
 }

--- a/src/main/java/com/nextroom/oescape/exceptions/StatusCode.java
+++ b/src/main/java/com/nextroom/oescape/exceptions/StatusCode.java
@@ -10,9 +10,20 @@ import lombok.Getter;
 public enum StatusCode {
 
     /**
-     * 4xx Bad Request
+     * 400 Bad Request
      */
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+
+    /**
+     * 404 Not Found
+     */
+    NOT_FOUND(HttpStatus.NOT_FOUND, "리소스를 찾을 수 없습니다."),
+    THEME_NOT_FOUNT(HttpStatus.NOT_FOUND, "등록된 테마가 없습니다."),
+
+    /**
+     * 409 Conflict
+     */
+    CONFLICT(HttpStatus.CONFLICT, "중복된 리소스 입니다."),
 
     /**
      * 2xx OK

--- a/src/main/java/com/nextroom/oescape/repository/ThemeRepository.java
+++ b/src/main/java/com/nextroom/oescape/repository/ThemeRepository.java
@@ -12,4 +12,6 @@ public interface ThemeRepository extends JpaRepository<Theme, Long> {
     Optional<Theme> findByTitle(String title);
 
     List<Theme> findAllByShop(Shop shop);
+
+    Optional<Theme> findByIdAndShop(Long id, Shop shop);
 }

--- a/src/test/java/com/nextroom/oescape/service/ThemeServiceTest.java
+++ b/src/test/java/com/nextroom/oescape/service/ThemeServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.nextroom.oescape.domain.Shop;
 import com.nextroom.oescape.domain.Theme;
 import com.nextroom.oescape.dto.ThemeDto;
 import com.nextroom.oescape.exceptions.CustomException;
@@ -39,6 +40,7 @@ class ThemeServiceTest {
 
         //when
         ThemeDto.AddThemeResponse result = themeService.addTheme(
+            new Shop(),
             ThemeDto.AddThemeRequest
                 .builder()
                 .title(title)
@@ -69,6 +71,7 @@ class ThemeServiceTest {
 
         //when
         CustomException result = assertThrows(CustomException.class, () -> themeService.addTheme(
+            new Shop(),
             ThemeDto.AddThemeRequest
                 .builder()
                 .title(title)


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가 (#19)

### 반영 브랜치
feature/theme → develop

### 작업 사항
- 테마 수정/삭제를 구현하였습니다.
- Service 계층 메서드가 변경되어 테스트 코드도 수정해주었습니다.
- 자주 사용하는 Status Code를 추가하였습니다.

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
Shop Entity가 없어 API 테스트를 진행하지 못했습니다.
현재 테스트 가능한 API는 '테마 등록' 입니다.
`POST /api/v1/theme` 로 다음과 같이 요청을 보내면 응답이 오는 걸 확인했습니다.

```json
{
    "title":"테마 제목",
    "timeLimit":70
}
```

![theme_create](https://github.com/Nexters/o-escape-be/assets/87196958/fbdf9f6d-52f8-437c-badb-7b72bcf65bb5)
