### PR TITLE
[FIX] SignUpRequestDto 객체 생성이 안되던 문제 해결

### DIFF
--- a/src/main/java/com/nextroom/oescape/dto/AuthDto.java
+++ b/src/main/java/com/nextroom/oescape/dto/AuthDto.java
@@ -1,7 +1,6 @@
 package com.nextroom.oescape.dto;
 
 import java.util.Collections;
-import java.util.List;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -9,15 +8,18 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.nextroom.oescape.domain.Authority;
 import com.nextroom.oescape.domain.Shop;
-import com.nextroom.oescape.domain.Theme;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 public class AuthDto {
     @Getter
     @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor(force = true)
     public static class SignUpRequestDto {
         private final String adminCode;
         @Setter
@@ -36,18 +38,12 @@ public class AuthDto {
     @Builder
     public static class SignUpResponseDto {
         private String adminCode;
-        private List<Theme> themes;
-
-        public static AuthDto.SignUpResponseDto of(Shop shop) {
-            return AuthDto.SignUpResponseDto.builder()
-                .adminCode(shop.getAdminCode())
-                .themes(shop.getThemes())
-                .build();
-        }
     }
 
     @Getter
     @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor(force = true)
     public static class LogInRequestDto {
         private final String adminCode;
         @Setter

--- a/src/main/java/com/nextroom/oescape/service/AuthService.java
+++ b/src/main/java/com/nextroom/oescape/service/AuthService.java
@@ -7,14 +7,14 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import com.nextroom.oescape.domain.RefreshToken;
+import com.nextroom.oescape.domain.Shop;
 import com.nextroom.oescape.dto.AuthDto;
 import com.nextroom.oescape.exceptions.CustomException;
 import com.nextroom.oescape.exceptions.StatusCode;
-import com.nextroom.oescape.security.TokenProvider;
-import com.nextroom.oescape.domain.RefreshToken;
-import com.nextroom.oescape.domain.Shop;
 import com.nextroom.oescape.repository.RefreshTokenRepository;
 import com.nextroom.oescape.repository.ShopRepository;
+import com.nextroom.oescape.security.TokenProvider;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -34,8 +34,10 @@ public class AuthService {
             throw new CustomException(StatusCode.SHOP_ALREADY_EXIST);
         }
 
-        Shop shop = request.toShop(passwordEncoder);
-        return AuthDto.SignUpResponseDto.of(shopRepository.save(shop));
+        Shop shop = shopRepository.save(request.toShop(passwordEncoder));
+
+        return AuthDto.SignUpResponseDto.builder()
+            .adminCode(shop.getAdminCode()).build();
     }
 
     @Transactional


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정

### 반영 브랜치
hotfix/constructor → develop

### 작업 사항
- Builder 사용 시 모든 필드를 포함하는 생성자가 필요합니다. @AllArgsConstructor 를 추가하였습니다.
- ObjectMapper가 내부적으로 Json을 Java로 변환할 때 기본 생성자가 필요합니다. @NoArgsConstructor 를 추가하였습니다.
- final 필드가 있을 시 (force = true) 옵션을 통해 강제 초기화를 합니다.

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
postman 테스트 결과 이상 없습니다!