### PR TITLE
[REFACTOR] Controller에 Swqgger 어노테이션 추가

### DIFF
--- a/src/main/java/com/nextroom/oescape/controller/AuthController.java
+++ b/src/main/java/com/nextroom/oescape/controller/AuthController.java
@@ -13,26 +13,51 @@ import com.nextroom.oescape.dto.BaseResponse;
 import com.nextroom.oescape.dto.DataResponse;
 import com.nextroom.oescape.service.AuthService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "Auth")
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
 public class AuthController {
     private final AuthService authService;
 
+    @Operation(
+        summary = "회원가입",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "403", description = "Unauthorized / Invalid Token")
+        }
+    )
     @PostMapping("/signup")
     public ResponseEntity<BaseResponse> signUp(@RequestBody AuthDto.SignUpRequestDto request) {
         request.setPassword(request.getAdminCode());
         return ResponseEntity.ok(new DataResponse<>(OK, authService.signUp(request)));
     }
 
+    @Operation(
+        summary = "로그인",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "403", description = "Unauthorized / Invalid Token")
+        }
+    )
     @PostMapping("/login")
     public ResponseEntity<BaseResponse> logIn(@RequestBody AuthDto.LogInRequestDto request) {
         request.setPassword(request.getAdminCode());
         return ResponseEntity.ok(new DataResponse<>(OK, authService.login(request)));
     }
 
+    @Operation(
+        summary = "토큰 재발급",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "403", description = "Unauthorized / Invalid Token")
+        }
+    )
     @PostMapping("/reissue")
     public ResponseEntity<BaseResponse> reissue(@RequestBody AuthDto.ReissueRequestDto request) {
         return ResponseEntity.ok(new DataResponse<>(OK, authService.reissue(request)));

--- a/src/main/java/com/nextroom/oescape/controller/HintController.java
+++ b/src/main/java/com/nextroom/oescape/controller/HintController.java
@@ -19,14 +19,25 @@ import com.nextroom.oescape.dto.DataResponse;
 import com.nextroom.oescape.dto.HintDto;
 import com.nextroom.oescape.service.HintService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "Hint")
 @RestController
 @RequestMapping("/api/v1/hint")
 @RequiredArgsConstructor
 public class HintController {
     private final HintService hintService;
 
+    @Operation(
+        summary = "힌트 등록",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "404", description = "HINT_NOT_FOUND")
+        }
+    )
     @PostMapping
     public ResponseEntity<BaseResponse> addHint(
         @AuthenticationPrincipal Shop shop,
@@ -35,12 +46,26 @@ public class HintController {
         return ResponseEntity.ok(new BaseResponse(OK));
     }
 
+    @Operation(
+        summary = "힌트 조회",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "404", description = "HINT_NOT_FOUND")
+        }
+    )
     @GetMapping
     public ResponseEntity<BaseResponse> getHintList(@AuthenticationPrincipal Shop shop,
         @RequestParam("themeId") Long themeId) {
         return ResponseEntity.ok(new DataResponse<>(OK, hintService.getHintList(shop, themeId)));
     }
 
+    @Operation(
+        summary = "힌트 수정",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "404", description = "HINT_NOT_FOUND")
+        }
+    )
     @PutMapping
     public ResponseEntity<BaseResponse> editHint(@AuthenticationPrincipal Shop shop,
         @RequestBody HintDto.EditHintRequest request) {
@@ -48,6 +73,13 @@ public class HintController {
         return ResponseEntity.ok(new BaseResponse(OK));
     }
 
+    @Operation(
+        summary = "힌트 삭제",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "404", description = "HINT_NOT_FOUND")
+        }
+    )
     @DeleteMapping
     public ResponseEntity<BaseResponse> removeHint(
         @AuthenticationPrincipal Shop shop,

--- a/src/main/java/com/nextroom/oescape/controller/ThemeController.java
+++ b/src/main/java/com/nextroom/oescape/controller/ThemeController.java
@@ -18,14 +18,25 @@ import com.nextroom.oescape.dto.DataResponse;
 import com.nextroom.oescape.dto.ThemeDto;
 import com.nextroom.oescape.service.ThemeService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "Theme")
 @RestController
 @RequestMapping("/api/v1/theme")
 @RequiredArgsConstructor
 public class ThemeController {
     private final ThemeService themeService;
 
+    @Operation(
+        summary = "테마 등록",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "404", description = "THEME_NOT_FOUND")
+        }
+    )
     @PostMapping
     public ResponseEntity<BaseResponse> addTheme(
         @AuthenticationPrincipal Shop shop,
@@ -34,11 +45,25 @@ public class ThemeController {
         return ResponseEntity.ok(new BaseResponse(OK));
     }
 
+    @Operation(
+        summary = "테마 조회",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "404", description = "THEME_NOT_FOUND")
+        }
+    )
     @GetMapping
     public ResponseEntity<BaseResponse> getThemeList(@AuthenticationPrincipal Shop shop) {
         return ResponseEntity.ok(new DataResponse<>(OK, themeService.getThemeList(shop)));
     }
 
+    @Operation(
+        summary = "테마 수정",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "404", description = "THEME_NOT_FOUND")
+        }
+    )
     @PutMapping
     public ResponseEntity<BaseResponse> editTheme(@AuthenticationPrincipal Shop shop,
         @RequestBody ThemeDto.EditThemeRequest request) {
@@ -46,6 +71,13 @@ public class ThemeController {
         return ResponseEntity.ok(new BaseResponse(OK));
     }
 
+    @Operation(
+        summary = "테마 삭제",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "404", description = "THEME_NOT_FOUND")
+        }
+    )
     @DeleteMapping
     public ResponseEntity<BaseResponse> removeTheme(
         @AuthenticationPrincipal Shop shop,

--- a/src/main/java/com/nextroom/oescape/dto/HintDto.java
+++ b/src/main/java/com/nextroom/oescape/dto/HintDto.java
@@ -9,6 +9,7 @@ public class HintDto {
 
     @Getter
     @RequiredArgsConstructor
+    @NoArgsConstructor(force = true)
     public static class AddHintRequest {
         private final Long themeId;
         private final String hintTitle;

--- a/src/main/java/com/nextroom/oescape/security/config/SecurityConfig.java
+++ b/src/main/java/com/nextroom/oescape/security/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return (web) -> web.ignoring()
-            .requestMatchers("/h2-console/**", "/favicon.ico");
+            .requestMatchers("/favicon.ico");
     }
 
     @Bean
@@ -60,7 +60,7 @@ public class SecurityConfig {
 
             .authorizeHttpRequests(
                 authorizationManagerRequestMatcherRegistry -> authorizationManagerRequestMatcherRegistry
-                    .requestMatchers("/api/v1/auth/**", "/h2-console/**")
+                    .requestMatchers("/api/v1/auth/**", "/swagger-ui/**", "/v3/**")
                     .permitAll()
                     .requestMatchers("/api/v1/theme/**")
                     .hasAnyAuthority("ROLE_USER")


### PR DESCRIPTION
### PR 타입
- [x] 코드 리팩토링

### 반영 브랜치
feature/swagger → develop

### 작업 사항
- TestController를 참고하여 모든 Controller에 Swagger 관련 어노테이션을 추가하였습니다.
- Swagger는 다음의 주소로 접속 가능합니다. `{url}/swagger-ui/index.html`

![swagger-api](https://github.com/Nexters/o-escape-be/assets/87196958/6360ebf1-1e84-478c-a7eb-e29d5984d493)


### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
postman 테스트 결과 이상 없습니다~