### PR TITLE
[FEAT] hint/theme api 내 shop 검증 로직 구현

### DIFF
--- a/src/main/java/com/nextroom/oescape/controller/AuthController.java
+++ b/src/main/java/com/nextroom/oescape/controller/AuthController.java
@@ -48,12 +48,8 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<BaseResponse> logIn(@RequestBody AuthDto.LogInRequestDto request) {
         request.setPassword(request.getAdminCode());
-        try {
-            return ResponseEntity.ok(new DataResponse<>(OK, authService.login(request)));
-        } catch (Exception e) {
-            System.out.println(e.toString());
-        }
-        return null;
+
+        return ResponseEntity.ok(new DataResponse<>(OK, authService.login(request)));
     }
 
     @Operation(

--- a/src/main/java/com/nextroom/oescape/controller/AuthController.java
+++ b/src/main/java/com/nextroom/oescape/controller/AuthController.java
@@ -48,7 +48,12 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<BaseResponse> logIn(@RequestBody AuthDto.LogInRequestDto request) {
         request.setPassword(request.getAdminCode());
-        return ResponseEntity.ok(new DataResponse<>(OK, authService.login(request)));
+        try {
+            return ResponseEntity.ok(new DataResponse<>(OK, authService.login(request)));
+        } catch (Exception e) {
+            System.out.println(e.toString());
+        }
+        return null;
     }
 
     @Operation(

--- a/src/main/java/com/nextroom/oescape/controller/HintController.java
+++ b/src/main/java/com/nextroom/oescape/controller/HintController.java
@@ -3,7 +3,6 @@ package com.nextroom.oescape.controller;
 import static com.nextroom.oescape.exceptions.StatusCode.*;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,7 +12,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.nextroom.oescape.domain.Shop;
 import com.nextroom.oescape.dto.BaseResponse;
 import com.nextroom.oescape.dto.DataResponse;
 import com.nextroom.oescape.dto.HintDto;
@@ -28,31 +26,25 @@ public class HintController {
     private final HintService hintService;
 
     @PostMapping
-    public ResponseEntity<BaseResponse> addHint(
-        @AuthenticationPrincipal Shop shop,
-        @RequestBody HintDto.AddHintRequest request) {
-        hintService.addHint(shop, request);
+    public ResponseEntity<BaseResponse> addHint(@RequestBody HintDto.AddHintRequest request) {
+        hintService.addHint(request);
         return ResponseEntity.ok(new BaseResponse(OK));
     }
 
     @GetMapping
-    public ResponseEntity<BaseResponse> getHintList(@AuthenticationPrincipal Shop shop,
-        @RequestParam("themeId") Long themeId) {
-        return ResponseEntity.ok(new DataResponse<>(OK, hintService.getHintList(shop, themeId)));
+    public ResponseEntity<BaseResponse> getHintList(@RequestParam("themeId") Long themeId) {
+        return ResponseEntity.ok(new DataResponse<>(OK, hintService.getHintList(themeId)));
     }
 
     @PutMapping
-    public ResponseEntity<BaseResponse> editHint(@AuthenticationPrincipal Shop shop,
-        @RequestBody HintDto.EditHintRequest request) {
-        hintService.editHint(shop, request);
+    public ResponseEntity<BaseResponse> editHint(@RequestBody HintDto.EditHintRequest request) {
+        hintService.editHint(request);
         return ResponseEntity.ok(new BaseResponse(OK));
     }
 
     @DeleteMapping
-    public ResponseEntity<BaseResponse> removeHint(
-        @AuthenticationPrincipal Shop shop,
-        @RequestBody HintDto.RemoveHintRequest request) {
-        hintService.removeHint(shop, request);
+    public ResponseEntity<BaseResponse> removeHint(@RequestBody HintDto.RemoveHintRequest request) {
+        hintService.removeHint(request);
         return ResponseEntity.ok(new BaseResponse(OK));
     }
 }

--- a/src/main/java/com/nextroom/oescape/controller/ThemeController.java
+++ b/src/main/java/com/nextroom/oescape/controller/ThemeController.java
@@ -3,7 +3,8 @@ package com.nextroom.oescape.controller;
 import static com.nextroom.oescape.exceptions.StatusCode.*;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.nextroom.oescape.domain.Shop;
 import com.nextroom.oescape.dto.BaseResponse;
 import com.nextroom.oescape.dto.DataResponse;
 import com.nextroom.oescape.dto.ThemeDto;
@@ -27,30 +27,28 @@ public class ThemeController {
     private final ThemeService themeService;
 
     @PostMapping
-    public ResponseEntity<BaseResponse> addTheme(
-        @AuthenticationPrincipal Shop shop,
-        @RequestBody ThemeDto.AddThemeRequest request) {
-        themeService.addTheme(shop, request);
+    public ResponseEntity<BaseResponse> addTheme(@RequestBody ThemeDto.AddThemeRequest request) {
+        themeService.addTheme(request);
         return ResponseEntity.ok(new BaseResponse(OK));
     }
 
     @GetMapping
-    public ResponseEntity<BaseResponse> getThemeList(@AuthenticationPrincipal Shop shop) {
-        return ResponseEntity.ok(new DataResponse<>(OK, themeService.getThemeList(shop)));
+    public ResponseEntity<BaseResponse> getThemeList() {
+        return ResponseEntity.ok(new DataResponse<>(OK, themeService.getThemeList()));
     }
 
     @PutMapping
-    public ResponseEntity<BaseResponse> editTheme(@AuthenticationPrincipal Shop shop,
-        @RequestBody ThemeDto.EditThemeRequest request) {
-        themeService.editTheme(shop, request);
+    public ResponseEntity<BaseResponse> editTheme(@RequestBody ThemeDto.EditThemeRequest request) {
+        themeService.editTheme(request);
         return ResponseEntity.ok(new BaseResponse(OK));
     }
 
     @DeleteMapping
-    public ResponseEntity<BaseResponse> removeTheme(
-        @AuthenticationPrincipal Shop shop,
-        @RequestBody ThemeDto.RemoveThemeRequest request) {
-        themeService.removeTheme(shop, request);
+    public ResponseEntity<BaseResponse> removeTheme(@RequestBody ThemeDto.RemoveThemeRequest request) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String username = authentication.getName();
+
+        themeService.removeTheme(request);
         return ResponseEntity.ok(new BaseResponse(OK));
     }
 }

--- a/src/main/java/com/nextroom/oescape/exceptions/StatusCode.java
+++ b/src/main/java/com/nextroom/oescape/exceptions/StatusCode.java
@@ -27,6 +27,7 @@ public enum StatusCode {
      */
     INVALID_TOKEN(HttpStatus.FORBIDDEN, "토큰의 유저 정보가 일치하지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "Refresh token 이 유효하지 않습니다."),
+    NOT_PERMITTED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
     /**
      * 404 Not Found
@@ -34,6 +35,8 @@ public enum StatusCode {
     NOT_FOUND(HttpStatus.NOT_FOUND, "리소스를 찾을 수 없습니다."),
     THEME_NOT_FOUND(HttpStatus.NOT_FOUND, "등록된 테마가 없습니다."),
     HINT_NOT_FOUND(HttpStatus.NOT_FOUND, "등록된 힌트가 없습니다."),
+    TARGET_THEME_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 테마입니다."),
+    TARGET_HINT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 힌트입니다."),
 
     /**
      * 409 Conflict

--- a/src/main/java/com/nextroom/oescape/security/SecurityUtil.java
+++ b/src/main/java/com/nextroom/oescape/security/SecurityUtil.java
@@ -3,6 +3,7 @@ package com.nextroom.oescape.security;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import com.nextroom.oescape.domain.Shop;
 import com.nextroom.oescape.exceptions.CustomException;
 import com.nextroom.oescape.exceptions.StatusCode;
 
@@ -22,5 +23,10 @@ public class SecurityUtil {
         }
 
         return Long.parseLong(authentication.getName());
+    }
+
+    public static String getRequestedShopAdminCode() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication.getPrincipal().toString();
     }
 }

--- a/src/main/java/com/nextroom/oescape/security/SecurityUtil.java
+++ b/src/main/java/com/nextroom/oescape/security/SecurityUtil.java
@@ -3,7 +3,6 @@ package com.nextroom.oescape.security;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-import com.nextroom.oescape.domain.Shop;
 import com.nextroom.oescape.exceptions.CustomException;
 import com.nextroom.oescape.exceptions.StatusCode;
 
@@ -25,8 +24,8 @@ public class SecurityUtil {
         return Long.parseLong(authentication.getName());
     }
 
-    public static String getRequestedShopAdminCode() {
+    public static Long getRequestedShopId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        return authentication.getPrincipal().toString();
+        return Long.parseLong(authentication.getPrincipal().toString());
     }
 }

--- a/src/main/java/com/nextroom/oescape/service/CustomUserDetailsService.java
+++ b/src/main/java/com/nextroom/oescape/service/CustomUserDetailsService.java
@@ -23,11 +23,10 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     @Transactional
-    public UserDetails loadUserByUsername(String idString) throws UsernameNotFoundException {
-        Long id = Long.parseLong(idString);
-        return shopRepository.findById(id)
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return shopRepository.findByAdminCode(username)
             .map(this::createUserDetails)
-            .orElseThrow(() -> new UsernameNotFoundException(id + " -> 데이터베이스에서 찾을 수 없습니다."));
+            .orElseThrow(() -> new UsernameNotFoundException(username + " -> 데이터베이스에서 찾을 수 없습니다."));
     }
 
     private UserDetails createUserDetails(Shop shop) {

--- a/src/main/java/com/nextroom/oescape/service/CustomUserDetailsService.java
+++ b/src/main/java/com/nextroom/oescape/service/CustomUserDetailsService.java
@@ -23,10 +23,11 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     @Transactional
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return shopRepository.findByAdminCode(username)
+    public UserDetails loadUserByUsername(String idString) throws UsernameNotFoundException {
+        Long id = Long.parseLong(idString);
+        return shopRepository.findById(id)
             .map(this::createUserDetails)
-            .orElseThrow(() -> new UsernameNotFoundException(username + " -> 데이터베이스에서 찾을 수 없습니다."));
+            .orElseThrow(() -> new UsernameNotFoundException(id + " -> 데이터베이스에서 찾을 수 없습니다."));
     }
 
     private UserDetails createUserDetails(Shop shop) {

--- a/src/main/java/com/nextroom/oescape/service/HintService.java
+++ b/src/main/java/com/nextroom/oescape/service/HintService.java
@@ -39,7 +39,7 @@ public class HintService {
             .progress(request.getProgress())
             .build();
 
-        if (!Objects.equals(theme.getShop().getAdminCode(), SecurityUtil.getRequestedShopAdminCode())) {
+        if (!Objects.equals(theme.getShop().getId(), SecurityUtil.getRequestedShopId())) {
             throw new CustomException(NOT_PERMITTED);
         }
 
@@ -52,7 +52,7 @@ public class HintService {
                 themeId) // TODO optimize by making method get theme from shop
             .orElseThrow(() -> new CustomException(THEME_NOT_FOUND));
 
-        if (!Objects.equals(theme.getShop().getAdminCode(), SecurityUtil.getRequestedShopAdminCode())) {
+        if (!Objects.equals(theme.getShop().getId(), SecurityUtil.getRequestedShopId())) {
             throw new CustomException(NOT_PERMITTED);
         }
 
@@ -65,7 +65,7 @@ public class HintService {
             () -> new CustomException(HINT_NOT_FOUND)
         );
 
-        if (!Objects.equals(hint.getTheme().getShop().getAdminCode(), SecurityUtil.getRequestedShopAdminCode())) {
+        if (!Objects.equals(hint.getTheme().getShop().getId(), SecurityUtil.getRequestedShopId())) {
             throw new CustomException(TARGET_HINT_NOT_FOUND);
         }
 
@@ -77,7 +77,7 @@ public class HintService {
             () -> new CustomException(HINT_NOT_FOUND)
         );
 
-        if (!Objects.equals(hint.getTheme().getShop().getAdminCode(), SecurityUtil.getRequestedShopAdminCode())) {
+        if (!Objects.equals(hint.getTheme().getShop().getId(), SecurityUtil.getRequestedShopId())) {
             throw new CustomException(TARGET_HINT_NOT_FOUND);
         }
 

--- a/src/main/java/com/nextroom/oescape/service/HintService.java
+++ b/src/main/java/com/nextroom/oescape/service/HintService.java
@@ -3,17 +3,18 @@ package com.nextroom.oescape.service;
 import static com.nextroom.oescape.exceptions.StatusCode.*;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.nextroom.oescape.domain.Hint;
-import com.nextroom.oescape.domain.Shop;
 import com.nextroom.oescape.domain.Theme;
 import com.nextroom.oescape.dto.HintDto;
 import com.nextroom.oescape.exceptions.CustomException;
 import com.nextroom.oescape.repository.HintRepository;
 import com.nextroom.oescape.repository.ThemeRepository;
+import com.nextroom.oescape.security.SecurityUtil;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,9 +25,7 @@ public class HintService {
     private final ThemeRepository themeRepository;
 
     @Transactional
-    public void addHint(Shop shop, HintDto.AddHintRequest request) {
-        validateTheme(shop, request.getThemeId());
-
+    public void addHint(HintDto.AddHintRequest request) {
         Theme theme = themeRepository.findById(
                 request.getThemeId()) // TODO optimize by making method get theme from shop
             .orElseThrow(() -> new CustomException(THEME_NOT_FOUND));
@@ -40,50 +39,48 @@ public class HintService {
             .progress(request.getProgress())
             .build();
 
+        if (!Objects.equals(theme.getShop().getAdminCode(), SecurityUtil.getRequestedShopAdminCode())) {
+            throw new CustomException(NOT_PERMITTED);
+        }
+
         hintRepository.save(hint);
     }
 
     @Transactional(readOnly = true)
-    public List<HintDto.HintListResponse> getHintList(Shop shop, Long themeId) {
-        validateTheme(shop, themeId);
-
+    public List<HintDto.HintListResponse> getHintList(Long themeId) {
         Theme theme = themeRepository.findById(
                 themeId) // TODO optimize by making method get theme from shop
             .orElseThrow(() -> new CustomException(THEME_NOT_FOUND));
+
+        if (!Objects.equals(theme.getShop().getAdminCode(), SecurityUtil.getRequestedShopAdminCode())) {
+            throw new CustomException(NOT_PERMITTED);
+        }
 
         return theme.getHints().stream().map(Hint::toHintListResponse).toList();
     }
 
     @Transactional
-    public void editHint(Shop shop, HintDto.EditHintRequest request) {
+    public void editHint(HintDto.EditHintRequest request) {
         Hint hint = hintRepository.findById(request.getId()).orElseThrow(
             () -> new CustomException(HINT_NOT_FOUND)
         );
+
+        if (!Objects.equals(hint.getTheme().getShop().getAdminCode(), SecurityUtil.getRequestedShopAdminCode())) {
+            throw new CustomException(TARGET_HINT_NOT_FOUND);
+        }
+
         hint.update(request);
     }
 
-    public void removeHint(Shop shop, HintDto.RemoveHintRequest request) {
+    public void removeHint(HintDto.RemoveHintRequest request) {
         Hint hint = hintRepository.findById(request.getId()).orElseThrow(
             () -> new CustomException(HINT_NOT_FOUND)
         );
+
+        if (!Objects.equals(hint.getTheme().getShop().getAdminCode(), SecurityUtil.getRequestedShopAdminCode())) {
+            throw new CustomException(TARGET_HINT_NOT_FOUND);
+        }
+
         hintRepository.delete(hint);
-    }
-
-    private void validateTheme(Shop shop, Long themeId) {
-        if (!themeRepository.existsByIdAndShop(themeId, shop)) {
-            throw new CustomException(THEME_NOT_FOUND);
-        }
-    }
-
-    private void validateHint(Shop shop, Long hintId) {
-        Boolean validity = false;
-        for (Theme theme : shop.getThemes()) {
-            if (hintRepository.existsById(hintId)) {
-                validity = true;
-            }
-        }
-        if (!validity) {
-            throw new CustomException(HINT_NOT_FOUND);
-        }
     }
 }

--- a/src/main/java/com/nextroom/oescape/service/ThemeService.java
+++ b/src/main/java/com/nextroom/oescape/service/ThemeService.java
@@ -4,6 +4,7 @@ import static com.nextroom.oescape.exceptions.StatusCode.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,7 +13,9 @@ import com.nextroom.oescape.domain.Shop;
 import com.nextroom.oescape.domain.Theme;
 import com.nextroom.oescape.dto.ThemeDto;
 import com.nextroom.oescape.exceptions.CustomException;
+import com.nextroom.oescape.repository.ShopRepository;
 import com.nextroom.oescape.repository.ThemeRepository;
+import com.nextroom.oescape.security.SecurityUtil;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,20 +23,27 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ThemeService {
     private final ThemeRepository themeRepository;
+    private final ShopRepository shopRepository;
 
     @Transactional
-    public void addTheme(Shop shop, ThemeDto.AddThemeRequest request) {
+    public void addTheme(ThemeDto.AddThemeRequest request) {
+        Shop shop = shopRepository.findByAdminCode(SecurityUtil.getRequestedShopAdminCode())
+            .orElseThrow(() -> new CustomException(TOKEN_UNAUTHORIZED));
+
         Theme theme = Theme.builder()
             .title(request.getTitle())
             .timeLimit(request.getTimeLimit())
             .shop(shop)
             .build();
 
+
         themeRepository.save(theme);
     }
 
     @Transactional(readOnly = true)
-    public List<ThemeDto.ThemeListResponse> getThemeList(Shop shop) {
+    public List<ThemeDto.ThemeListResponse> getThemeList() {
+        Shop shop = shopRepository.findByAdminCode(SecurityUtil.getRequestedShopAdminCode())
+            .orElseThrow(() -> new CustomException(TOKEN_UNAUTHORIZED));
         List<Theme> themeList = themeRepository.findAllByShop(shop);
         if (themeList.size() == 0) {
             throw new CustomException(THEME_NOT_FOUND);
@@ -51,14 +61,20 @@ public class ThemeService {
     }
 
     @Transactional
-    public void editTheme(Shop shop, ThemeDto.EditThemeRequest request) {
+    public void editTheme(ThemeDto.EditThemeRequest request) {
+        Shop shop = shopRepository.findByAdminCode(SecurityUtil.getRequestedShopAdminCode())
+            .orElseThrow(() -> new CustomException(TOKEN_UNAUTHORIZED));
+
         Theme theme = themeRepository.findByIdAndShop(request.getId(), shop).orElseThrow(
             () -> new CustomException(THEME_NOT_FOUND)
         );
         theme.update(request);
     }
 
-    public void removeTheme(Shop shop, ThemeDto.RemoveThemeRequest request) {
+    public void removeTheme(ThemeDto.RemoveThemeRequest request) {
+        Shop shop = shopRepository.findByAdminCode(SecurityUtil.getRequestedShopAdminCode())
+            .orElseThrow(() -> new CustomException(TOKEN_UNAUTHORIZED));
+
         Theme theme = themeRepository.findByIdAndShop(request.getId(), shop).orElseThrow(
             () -> new CustomException(THEME_NOT_FOUND)
         );

--- a/src/main/java/com/nextroom/oescape/service/ThemeService.java
+++ b/src/main/java/com/nextroom/oescape/service/ThemeService.java
@@ -27,7 +27,7 @@ public class ThemeService {
 
     @Transactional
     public void addTheme(ThemeDto.AddThemeRequest request) {
-        Shop shop = shopRepository.findByAdminCode(SecurityUtil.getRequestedShopAdminCode())
+        Shop shop = shopRepository.findById(SecurityUtil.getRequestedShopId())
             .orElseThrow(() -> new CustomException(TOKEN_UNAUTHORIZED));
 
         Theme theme = Theme.builder()
@@ -36,13 +36,12 @@ public class ThemeService {
             .shop(shop)
             .build();
 
-
         themeRepository.save(theme);
     }
 
     @Transactional(readOnly = true)
     public List<ThemeDto.ThemeListResponse> getThemeList() {
-        Shop shop = shopRepository.findByAdminCode(SecurityUtil.getRequestedShopAdminCode())
+        Shop shop = shopRepository.findById(SecurityUtil.getRequestedShopId())
             .orElseThrow(() -> new CustomException(TOKEN_UNAUTHORIZED));
         List<Theme> themeList = themeRepository.findAllByShop(shop);
         if (themeList.size() == 0) {
@@ -62,7 +61,7 @@ public class ThemeService {
 
     @Transactional
     public void editTheme(ThemeDto.EditThemeRequest request) {
-        Shop shop = shopRepository.findByAdminCode(SecurityUtil.getRequestedShopAdminCode())
+        Shop shop = shopRepository.findById(SecurityUtil.getRequestedShopId())
             .orElseThrow(() -> new CustomException(TOKEN_UNAUTHORIZED));
 
         Theme theme = themeRepository.findByIdAndShop(request.getId(), shop).orElseThrow(
@@ -72,7 +71,7 @@ public class ThemeService {
     }
 
     public void removeTheme(ThemeDto.RemoveThemeRequest request) {
-        Shop shop = shopRepository.findByAdminCode(SecurityUtil.getRequestedShopAdminCode())
+        Shop shop = shopRepository.findById(SecurityUtil.getRequestedShopId())
             .orElseThrow(() -> new CustomException(TOKEN_UNAUTHORIZED));
 
         Theme theme = themeRepository.findByIdAndShop(request.getId(), shop).orElseThrow(


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가

### 반영 브랜치
feature/shop-auth → develop

### 작업 사항
- hint, theme service 내에서도 업체를 검증하기 위해 인증 정보를 통해 검증하는 로직을 구현했습니다.

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
postman 기반 명세 내 api 모두 잘 동작합니다.