### PR TITLE
[FIX] android 인증 면제

### DIFF
--- a/src/main/java/com/nextroom/oescape/controller/ThemeController.java
+++ b/src/main/java/com/nextroom/oescape/controller/ThemeController.java
@@ -3,14 +3,13 @@ package com.nextroom.oescape.controller;
 import static com.nextroom.oescape.exceptions.StatusCode.*;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nextroom.oescape.dto.BaseResponse;
@@ -51,7 +50,11 @@ public class ThemeController {
         }
     )
     @GetMapping
-    public ResponseEntity<BaseResponse> getThemeList() {
+    public ResponseEntity<BaseResponse> getThemeList(
+        @RequestParam(value = "adminCode", required = false) String adminCode) {
+        if (adminCode != null) {
+            return ResponseEntity.ok(new DataResponse<>(OK, themeService.getThemeListByAdminCode(adminCode)));
+        }
         return ResponseEntity.ok(new DataResponse<>(OK, themeService.getThemeList()));
     }
 
@@ -77,9 +80,6 @@ public class ThemeController {
     )
     @DeleteMapping
     public ResponseEntity<BaseResponse> removeTheme(@RequestBody ThemeDto.RemoveThemeRequest request) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String username = authentication.getName();
-
         themeService.removeTheme(request);
         return ResponseEntity.ok(new BaseResponse(OK));
     }

--- a/src/main/java/com/nextroom/oescape/exceptions/StatusCode.java
+++ b/src/main/java/com/nextroom/oescape/exceptions/StatusCode.java
@@ -37,6 +37,7 @@ public enum StatusCode {
     HINT_NOT_FOUND(HttpStatus.NOT_FOUND, "등록된 힌트가 없습니다."),
     TARGET_THEME_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 테마입니다."),
     TARGET_HINT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 힌트입니다."),
+    TARGET_SHOP_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 업체입니다."),
 
     /**
      * 409 Conflict

--- a/src/main/java/com/nextroom/oescape/security/config/SecurityConfig.java
+++ b/src/main/java/com/nextroom/oescape/security/config/SecurityConfig.java
@@ -88,7 +88,6 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.addAllowedOrigin("*:3000");
         configuration.addAllowedOrigin("*");
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");

--- a/src/main/java/com/nextroom/oescape/security/config/SecurityConfig.java
+++ b/src/main/java/com/nextroom/oescape/security/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.nextroom.oescape.security.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -64,6 +65,8 @@ public class SecurityConfig {
                     .permitAll()
                     .requestMatchers("/api/v1/theme/**")
                     .hasAnyAuthority("ROLE_USER")
+                    .requestMatchers(HttpMethod.GET, "/api/v1/theme/**", "/api/v1/hint/**")
+                    .permitAll() // Android 인증 면제
                     .anyRequest()
                     .authenticated()
             )
@@ -85,6 +88,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
+        configuration.addAllowedOrigin("*:3000");
         configuration.addAllowedOrigin("*");
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");

--- a/src/main/java/com/nextroom/oescape/service/ThemeService.java
+++ b/src/main/java/com/nextroom/oescape/service/ThemeService.java
@@ -4,7 +4,6 @@ import static com.nextroom.oescape.exceptions.StatusCode.*;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -78,5 +77,22 @@ public class ThemeService {
             () -> new CustomException(THEME_NOT_FOUND)
         );
         themeRepository.delete(theme);
+    }
+
+    public List<ThemeDto.ThemeListResponse> getThemeListByAdminCode(String adminCode) {
+        Shop shop = shopRepository.findByAdminCode(adminCode)
+            .orElseThrow(() -> new CustomException(TARGET_SHOP_NOT_FOUND));
+
+        List<Theme> themeList = themeRepository.findAllByShop(shop);
+        List<ThemeDto.ThemeListResponse> themeListResponses = new ArrayList<>();
+        for (Theme theme : themeList) {
+            themeListResponses.add(ThemeDto.ThemeListResponse
+                .builder()
+                .id(theme.getId())
+                .title(theme.getTitle())
+                .timeLimit(theme.getTimeLimit())
+                .build());
+        }
+        return themeListResponses;
     }
 }


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정

### 반영 브랜치
hotfix/android-auth → develop

### 작업 사항
- theme, hint의 get method 인증 면제를 통해 안드로이드에서 토큰 없이 접근할 수 있도록 구현했습니다.
- 안드로이드에서 토큰 없이 theme 조회할 수 있도록 분기 로직을 구현했습니다.

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
postman으로 토큰 없이 테스트 진행했고, 잘 동작하는것 확인했습니다!