### PR TITLE
[FIX] Security 로직 내 예외 처리 구현

### DIFF
--- a/src/main/java/com/nextroom/oescape/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/nextroom/oescape/exceptions/GlobalExceptionHandler.java
@@ -60,7 +60,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(value = {AuthenticationException.class})
     protected ResponseEntity<ErrorResponse> handleAuthenticationException(AuthenticationException e) {
-        return ErrorResponse.toResponseEntity(HttpStatus.NOT_FOUND, "존재하지 않는 업체입니다.");
+        return ErrorResponse.toResponseEntity(HttpStatus.BAD_REQUEST, "관리자 코드 또는 패스워드가 잘못되었습니다.");
     }
 
 }

--- a/src/main/java/com/nextroom/oescape/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/nextroom/oescape/exceptions/GlobalExceptionHandler.java
@@ -33,34 +33,4 @@ public class GlobalExceptionHandler {
         return ErrorResponse.toResponseEntity(HttpStatus.BAD_REQUEST, e.getMessage());
     }
 
-    @ExceptionHandler(value = {io.jsonwebtoken.security.SecurityException.class})
-    protected ResponseEntity<ErrorResponse> handleSecurityException(io.jsonwebtoken.security.SecurityException e) {
-        return ErrorResponse.toResponseEntity(HttpStatus.BAD_REQUEST, "잘못된 JWT 서명입니다.");
-    }
-
-    @ExceptionHandler(value = {MalformedJwtException.class})
-    protected ResponseEntity<ErrorResponse> handleMalformedJwtException(MalformedJwtException e) {
-        return ErrorResponse.toResponseEntity(HttpStatus.BAD_REQUEST, "잘못된 JWT 서명입니다.");
-    }
-
-    @ExceptionHandler(value = {ExpiredJwtException.class})
-    protected ResponseEntity<ErrorResponse> handleExpiredJwtException(ExpiredJwtException e) {
-        return ErrorResponse.toResponseEntity(HttpStatus.BAD_REQUEST, "만료된 JWT 토큰입니다.");
-    }
-
-    @ExceptionHandler(value = {UnsupportedJwtException.class})
-    protected ResponseEntity<ErrorResponse> handleUnsupportedJwtException(UnsupportedJwtException e) {
-        return ErrorResponse.toResponseEntity(HttpStatus.BAD_REQUEST, "지원되지 않는 JWT 토큰입니다.");
-    }
-
-    @ExceptionHandler(value = {IllegalArgumentException.class})
-    protected ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
-        return ErrorResponse.toResponseEntity(HttpStatus.BAD_REQUEST, "JWT 토큰이 잘못되었습니다.");
-    }
-
-    @ExceptionHandler(value = {AuthenticationException.class})
-    protected ResponseEntity<ErrorResponse> handleAuthenticationException(AuthenticationException e) {
-        return ErrorResponse.toResponseEntity(HttpStatus.BAD_REQUEST, "관리자 코드 또는 패스워드가 잘못되었습니다.");
-    }
-
 }

--- a/src/main/java/com/nextroom/oescape/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/nextroom/oescape/exceptions/GlobalExceptionHandler.java
@@ -9,6 +9,10 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -27,4 +31,30 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
         return ErrorResponse.toResponseEntity(HttpStatus.BAD_REQUEST, e.getMessage());
     }
+
+    @ExceptionHandler(value = {io.jsonwebtoken.security.SecurityException.class})
+    protected ResponseEntity<ErrorResponse> handleSecurityException(io.jsonwebtoken.security.SecurityException e) {
+        return ErrorResponse.toResponseEntity(HttpStatus.BAD_REQUEST, "잘못된 JWT 서명입니다.");
+    }
+
+    @ExceptionHandler(value = {MalformedJwtException.class})
+    protected ResponseEntity<ErrorResponse> handleMalformedJwtException(MalformedJwtException e) {
+        return ErrorResponse.toResponseEntity(HttpStatus.BAD_REQUEST, "잘못된 JWT 서명입니다.");
+    }
+
+    @ExceptionHandler(value = {ExpiredJwtException.class})
+    protected ResponseEntity<ErrorResponse> handleExpiredJwtException(ExpiredJwtException e) {
+        return ErrorResponse.toResponseEntity(HttpStatus.BAD_REQUEST, "만료된 JWT 토큰입니다.");
+    }
+
+    @ExceptionHandler(value = {UnsupportedJwtException.class})
+    protected ResponseEntity<ErrorResponse> handleUnsupportedJwtException(UnsupportedJwtException e) {
+        return ErrorResponse.toResponseEntity(HttpStatus.BAD_REQUEST, "지원되지 않는 JWT 토큰입니다.");
+    }
+
+    @ExceptionHandler(value = {IllegalArgumentException.class})
+    protected ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
+        return ErrorResponse.toResponseEntity(HttpStatus.BAD_REQUEST, "JWT 토큰이 잘못되었습니다.");
+    }
+
 }

--- a/src/main/java/com/nextroom/oescape/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/nextroom/oescape/exceptions/GlobalExceptionHandler.java
@@ -5,14 +5,9 @@ import java.util.Objects;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {

--- a/src/main/java/com/nextroom/oescape/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/nextroom/oescape/exceptions/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -55,6 +56,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(value = {IllegalArgumentException.class})
     protected ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
         return ErrorResponse.toResponseEntity(HttpStatus.BAD_REQUEST, "JWT 토큰이 잘못되었습니다.");
+    }
+
+    @ExceptionHandler(value = {AuthenticationException.class})
+    protected ResponseEntity<ErrorResponse> handleAuthenticationException(AuthenticationException e) {
+        return ErrorResponse.toResponseEntity(HttpStatus.NOT_FOUND, "존재하지 않는 업체입니다.");
     }
 
 }

--- a/src/main/java/com/nextroom/oescape/exceptions/StatusCode.java
+++ b/src/main/java/com/nextroom/oescape/exceptions/StatusCode.java
@@ -15,17 +15,19 @@ public enum StatusCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     AUTH_BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     SHOP_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "업체가 이미 존재합니다."),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "잘못된 토큰입니다."),
+    UNSUPPORTED_TOKEN(HttpStatus.BAD_REQUEST, "지원하지 않는 토큰 형식입니다."),
 
     /**
      * 401 Unauthorized
      */
     TOKEN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "권한 정보가 잘못된 토큰입니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     SHOP_IS_LOG_OUT(HttpStatus.UNAUTHORIZED, "로그아웃 된 사용자입니다."),
 
     /**
      * 403 FORBIDDEN
      */
-    INVALID_TOKEN(HttpStatus.FORBIDDEN, "토큰의 유저 정보가 일치하지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "Refresh token 이 유효하지 않습니다."),
     NOT_PERMITTED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 

--- a/src/main/java/com/nextroom/oescape/exceptions/StatusCode.java
+++ b/src/main/java/com/nextroom/oescape/exceptions/StatusCode.java
@@ -17,6 +17,7 @@ public enum StatusCode {
     SHOP_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "업체가 이미 존재합니다."),
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "잘못된 토큰입니다."),
     UNSUPPORTED_TOKEN(HttpStatus.BAD_REQUEST, "지원하지 않는 토큰 형식입니다."),
+    INVALID_TOKEN_SIGNATURE(HttpStatus.BAD_REQUEST, "잘못된 토큰 서명입니다."),
 
     /**
      * 401 Unauthorized

--- a/src/main/java/com/nextroom/oescape/security/ExceptionHandlerFilter.java
+++ b/src/main/java/com/nextroom/oescape/security/ExceptionHandlerFilter.java
@@ -1,5 +1,7 @@
 package com.nextroom.oescape.security;
 
+import static com.nextroom.oescape.exceptions.StatusCode.*;
+
 import java.io.IOException;
 
 import org.springframework.http.MediaType;
@@ -9,6 +11,7 @@ import com.fasterxml.jackson.core.json.JsonWriteFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nextroom.oescape.exceptions.CustomException;
 import com.nextroom.oescape.exceptions.ErrorResponse;
+import com.nextroom.oescape.exceptions.StatusCode;
 import com.nextroom.oescape.exceptions.StatusCode;
 
 import io.jsonwebtoken.ExpiredJwtException;
@@ -30,13 +33,13 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
         try {
             filterChain.doFilter(request, response);
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-            setErrorResponse(response, StatusCode.INVALID_TOKEN_SIGNATURE);
+            setErrorResponse(response, INVALID_TOKEN_SIGNATURE);
         } catch (ExpiredJwtException e) {
-            setErrorResponse(response, StatusCode.TOKEN_EXPIRED);
+            setErrorResponse(response, TOKEN_EXPIRED);
         } catch (UnsupportedJwtException e) {
-            setErrorResponse(response, StatusCode.UNSUPPORTED_TOKEN);
+            setErrorResponse(response, UNSUPPORTED_TOKEN);
         } catch (IllegalArgumentException | JwtException e) {
-            setErrorResponse(response, StatusCode.INVALID_TOKEN);
+            setErrorResponse(response, INVALID_TOKEN);
         } catch (CustomException e) {
             setErrorResponse(response, e.getStatusCode());
         }

--- a/src/main/java/com/nextroom/oescape/security/ExceptionHandlerFilter.java
+++ b/src/main/java/com/nextroom/oescape/security/ExceptionHandlerFilter.java
@@ -1,0 +1,63 @@
+package com.nextroom.oescape.security;
+
+import java.io.IOException;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.core.json.JsonWriteFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nextroom.oescape.exceptions.CustomException;
+import com.nextroom.oescape.exceptions.ErrorResponse;
+import com.nextroom.oescape.exceptions.StatusCode;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+
+        FilterChain filterChain) throws ServletException, IOException {
+
+        try {
+            filterChain.doFilter(request, response);
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            setErrorResponse(response, StatusCode.INVALID_TOKEN_SIGNATURE);
+        } catch (ExpiredJwtException e) {
+            setErrorResponse(response, StatusCode.TOKEN_EXPIRED);
+        } catch (UnsupportedJwtException e) {
+            setErrorResponse(response, StatusCode.UNSUPPORTED_TOKEN);
+        } catch (IllegalArgumentException | JwtException e) {
+            setErrorResponse(response, StatusCode.INVALID_TOKEN);
+        } catch (CustomException e) {
+            setErrorResponse(response, e.getStatusCode());
+        }
+    }
+
+    private void setErrorResponse(HttpServletResponse response, StatusCode statusCode) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.getFactory().configure(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature(), true);
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        try {
+            response.getWriter().write(objectMapper.writeValueAsString(
+                    ErrorResponse.builder()
+                        .code(statusCode.getCode().value())
+                        .message(statusCode.getMessage())
+                        .build()
+                )
+            );
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/com/nextroom/oescape/security/SecurityUtil.java
+++ b/src/main/java/com/nextroom/oescape/security/SecurityUtil.java
@@ -1,10 +1,11 @@
 package com.nextroom.oescape.security;
 
+import static com.nextroom.oescape.exceptions.StatusCode.*;
+
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import com.nextroom.oescape.exceptions.CustomException;
-import com.nextroom.oescape.exceptions.StatusCode;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,7 +19,7 @@ public class SecurityUtil {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null || authentication.getName() == null) {
-            throw new CustomException(StatusCode.INVALID_REFRESH_TOKEN);
+            throw new CustomException(INVALID_REFRESH_TOKEN);
         }
 
         return Long.parseLong(authentication.getName());

--- a/src/main/java/com/nextroom/oescape/security/TokenProvider.java
+++ b/src/main/java/com/nextroom/oescape/security/TokenProvider.java
@@ -22,9 +22,7 @@ import com.nextroom.oescape.exceptions.StatusCode;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
@@ -93,19 +91,8 @@ public class TokenProvider {
     }
 
     public boolean validateToken(String token) {
-        try {
-            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-            return true;
-        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-            log.info("잘못된 JWT 서명입니다.");
-        } catch (ExpiredJwtException e) {
-            log.info("만료된 JWT 토큰입니다.");
-        } catch (UnsupportedJwtException e) {
-            log.info("지원되지 않는 JWT 토큰입니다.");
-        } catch (IllegalArgumentException e) {
-            log.info("JWT 토큰이 잘못되었습니다.");
-        }
-        return false;
+        Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+        return true;
     }
 
     private Claims parseClaims(String accessToken) {

--- a/src/main/java/com/nextroom/oescape/security/TokenProvider.java
+++ b/src/main/java/com/nextroom/oescape/security/TokenProvider.java
@@ -1,5 +1,7 @@
 package com.nextroom.oescape.security;
 
+import static com.nextroom.oescape.exceptions.StatusCode.*;
+
 import java.security.Key;
 import java.util.Arrays;
 import java.util.Collection;
@@ -17,7 +19,6 @@ import org.springframework.stereotype.Component;
 
 import com.nextroom.oescape.dto.TokenDto;
 import com.nextroom.oescape.exceptions.CustomException;
-import com.nextroom.oescape.exceptions.StatusCode;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -76,7 +77,7 @@ public class TokenProvider {
         Claims claims = parseClaims(accessToken);
 
         if (claims.get(AUTHORITIES_KEY) == null) {
-            throw new CustomException(StatusCode.TOKEN_UNAUTHORIZED);
+            throw new CustomException(TOKEN_UNAUTHORIZED);
         }
 
         Collection<? extends GrantedAuthority> authorities =

--- a/src/main/java/com/nextroom/oescape/security/config/SecurityConfig.java
+++ b/src/main/java/com/nextroom/oescape/security/config/SecurityConfig.java
@@ -12,10 +12,12 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import com.nextroom.oescape.security.ExceptionHandlerFilter;
 import com.nextroom.oescape.security.TokenProvider;
 import com.nextroom.oescape.security.jwt.JwtAccessDeniedHandler;
 import com.nextroom.oescape.security.jwt.JwtAuthenticationEntryPoint;
@@ -44,6 +46,8 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+            .addFilterBefore(new ExceptionHandlerFilter(), UsernamePasswordAuthenticationFilter.class)
+
             .csrf(AbstractHttpConfigurer::disable)
 
             // exception handling

--- a/src/main/java/com/nextroom/oescape/service/AuthService.java
+++ b/src/main/java/com/nextroom/oescape/service/AuthService.java
@@ -5,7 +5,6 @@ import static com.nextroom.oescape.util.Timestamped.*;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -51,21 +50,17 @@ public class AuthService {
 
         UsernamePasswordAuthenticationToken authenticationToken = request.toAuthentication();
 
-        try {
-            Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
-            AuthDto.LogInResponseDto response = tokenProvider.generateTokenDto(authentication).toLogInResponseDto();
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+        AuthDto.LogInResponseDto response = tokenProvider.generateTokenDto(authentication).toLogInResponseDto();
 
-            RefreshToken refreshToken = RefreshToken.builder()
-                .key(authentication.getName())
-                .value(response.getRefreshToken())
-                .build();
+        RefreshToken refreshToken = RefreshToken.builder()
+            .key(authentication.getName())
+            .value(response.getRefreshToken())
+            .build();
 
-            refreshTokenRepository.save(refreshToken);
+        refreshTokenRepository.save(refreshToken);
 
-            return response;
-        } catch (AuthenticationException e) {
-            throw new CustomException(StatusCode.TARGET_SHOP_NOT_FOUND);
-        }
+        return response;
     }
 
     @Transactional

--- a/src/main/java/com/nextroom/oescape/service/AuthService.java
+++ b/src/main/java/com/nextroom/oescape/service/AuthService.java
@@ -66,7 +66,7 @@ public class AuthService {
     @Transactional
     public AuthDto.ReissueResponseDto reissue(AuthDto.ReissueRequestDto request) {
         if (!tokenProvider.validateToken(request.getRefreshToken())) {
-            throw new CustomException(StatusCode.INVALID_TOKEN);
+            throw new CustomException(StatusCode.INVALID_REFRESH_TOKEN);
         }
 
         Authentication authentication = tokenProvider.getAuthentication(request.getAccessToken());
@@ -75,7 +75,7 @@ public class AuthService {
             .orElseThrow(() -> new CustomException(StatusCode.SHOP_IS_LOG_OUT));
 
         if (!refreshToken.getValue().equals(request.getRefreshToken())) {
-            throw new CustomException(StatusCode.INVALID_TOKEN);
+            throw new CustomException(StatusCode.INVALID_REFRESH_TOKEN);
         }
 
         AuthDto.ReissueResponseDto response = tokenProvider.generateTokenDto(authentication).toReissueResponseDto();

--- a/src/main/java/com/nextroom/oescape/service/AuthService.java
+++ b/src/main/java/com/nextroom/oescape/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.nextroom.oescape.service;
 
+import static com.nextroom.oescape.exceptions.StatusCode.*;
 import static com.nextroom.oescape.util.Timestamped.*;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -13,7 +14,6 @@ import com.nextroom.oescape.domain.RefreshToken;
 import com.nextroom.oescape.domain.Shop;
 import com.nextroom.oescape.dto.AuthDto;
 import com.nextroom.oescape.exceptions.CustomException;
-import com.nextroom.oescape.exceptions.StatusCode;
 import com.nextroom.oescape.repository.RefreshTokenRepository;
 import com.nextroom.oescape.repository.ShopRepository;
 import com.nextroom.oescape.security.TokenProvider;
@@ -33,7 +33,7 @@ public class AuthService {
     @Transactional
     public AuthDto.SignUpResponseDto signUp(AuthDto.SignUpRequestDto request) {
         if (shopRepository.existsByAdminCode(request.getAdminCode())) {
-            throw new CustomException(StatusCode.SHOP_ALREADY_EXIST);
+            throw new CustomException(SHOP_ALREADY_EXIST);
         }
 
         Shop shop = shopRepository.save(request.toShop(passwordEncoder));
@@ -66,16 +66,16 @@ public class AuthService {
     @Transactional
     public AuthDto.ReissueResponseDto reissue(AuthDto.ReissueRequestDto request) {
         if (!tokenProvider.validateToken(request.getRefreshToken())) {
-            throw new CustomException(StatusCode.INVALID_REFRESH_TOKEN);
+            throw new CustomException(INVALID_REFRESH_TOKEN);
         }
 
         Authentication authentication = tokenProvider.getAuthentication(request.getAccessToken());
 
         RefreshToken refreshToken = refreshTokenRepository.findByKey(authentication.getName())
-            .orElseThrow(() -> new CustomException(StatusCode.SHOP_IS_LOG_OUT));
+            .orElseThrow(() -> new CustomException(SHOP_IS_LOG_OUT));
 
         if (!refreshToken.getValue().equals(request.getRefreshToken())) {
-            throw new CustomException(StatusCode.INVALID_REFRESH_TOKEN);
+            throw new CustomException(INVALID_REFRESH_TOKEN);
         }
 
         AuthDto.ReissueResponseDto response = tokenProvider.generateTokenDto(authentication).toReissueResponseDto();


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링

### 반영 브랜치
feature/token-exception-handling → develop

### 작업 사항
- security filter chain 내의 exception 을 handling 할 수 있는 filterChain 을 새로 정의하고 구현했습니다.
- 상황에 맞지 않는 Exception 정의를 수정했습니다.

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
postman 실행 이상 없이 이제 security 로직 내 에러도 응답으로 잘 내려줍니다!