### PR TITLE
[REFACTOR] Login 성공 응답에 shopName 추가

### DIFF
--- a/src/main/java/com/nextroom/oescape/dto/AuthDto.java
+++ b/src/main/java/com/nextroom/oescape/dto/AuthDto.java
@@ -86,10 +86,21 @@ public class AuthDto {
     @Getter
     @Builder
     public static class LogInResponseDto {
+        private String shopName;
         private String grantType;
         private String accessToken;
         private long accessTokenExpiresIn;
         private String refreshToken;
+
+        public static AuthDto.LogInResponseDto toLogInResponseDto(String shopName, TokenDto tokenDto) {
+            return new LogInResponseDtoBuilder()
+                .shopName(shopName)
+                .grantType(tokenDto.getGrantType())
+                .accessToken(tokenDto.getAccessToken())
+                .accessTokenExpiresIn(tokenDto.getAccessTokenExpiresIn())
+                .refreshToken(tokenDto.getRefreshToken())
+                .build();
+        }
     }
 
     @Getter

--- a/src/main/java/com/nextroom/oescape/dto/TokenDto.java
+++ b/src/main/java/com/nextroom/oescape/dto/TokenDto.java
@@ -11,15 +11,14 @@ public class TokenDto {
     private long accessTokenExpiresIn;
     private String refreshToken;
 
-    public AuthDto.LogInResponseDto toLogInResponseDto() {
-        return new AuthDto.LogInResponseDto.LogInResponseDtoBuilder()
+    public TokenDto toTokenResponseDto() {
+        return new TokenDto.TokenDtoBuilder()
             .grantType(this.grantType)
             .accessToken(this.accessToken)
             .accessTokenExpiresIn(this.accessTokenExpiresIn)
             .refreshToken(this.refreshToken)
             .build();
     }
-
 
     public AuthDto.ReissueResponseDto toReissueResponseDto() {
         return new AuthDto.ReissueResponseDto.ReissueResponseDtoBuilder()

--- a/src/main/java/com/nextroom/oescape/repository/ShopRepository.java
+++ b/src/main/java/com/nextroom/oescape/repository/ShopRepository.java
@@ -1,6 +1,5 @@
 package com.nextroom.oescape.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,5 +8,6 @@ import com.nextroom.oescape.domain.Shop;
 
 public interface ShopRepository extends JpaRepository<Shop, Long> {
     boolean existsByAdminCode(String adminCode);
+
     Optional<Shop> findByAdminCode(String adminCode);
 }

--- a/src/main/java/com/nextroom/oescape/service/AuthService.java
+++ b/src/main/java/com/nextroom/oescape/service/AuthService.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import com.nextroom.oescape.domain.RefreshToken;
 import com.nextroom.oescape.domain.Shop;
 import com.nextroom.oescape.dto.AuthDto;
+import com.nextroom.oescape.dto.TokenDto;
 import com.nextroom.oescape.exceptions.CustomException;
 import com.nextroom.oescape.exceptions.StatusCode;
 import com.nextroom.oescape.repository.RefreshTokenRepository;
@@ -53,11 +54,14 @@ public class AuthService {
 
         try {
             Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
-            AuthDto.LogInResponseDto response = tokenProvider.generateTokenDto(authentication).toLogInResponseDto();
+            TokenDto token = tokenProvider.generateTokenDto(authentication).toTokenResponseDto();
+            String shopName = shopRepository.findByAdminCode(request.getAdminCode())
+                .orElseThrow(() -> new CustomException(StatusCode.TARGET_SHOP_NOT_FOUND)).getName();
+            AuthDto.LogInResponseDto response = AuthDto.LogInResponseDto.toLogInResponseDto(shopName, token);
 
             RefreshToken refreshToken = RefreshToken.builder()
                 .key(authentication.getName())
-                .value(response.getRefreshToken())
+                .value(token.getRefreshToken())
                 .build();
 
             refreshTokenRepository.save(refreshToken);


### PR DESCRIPTION
### PR 타입
- [x] 코드 리팩토링 (#57)

### 반영 브랜치
feature/login-response → develop

### 작업 사항
- LoginResponseDto와 TokenDto를 분리하여 비즈니스 로직에 유연하게 대처할 수 있도록 리팩토링 하였습니다.
- 로그인 성공 시 shopName을 확인할 수 있습니다.

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
postman 테스트 결과 이상 없습니다!