### PR TITLE
[HOTFIX] 토큰 검증 관련 에러 시 잘못된 응답 코드 수정

### DIFF
--- a/src/main/java/com/nextroom/oescape/security/ExceptionHandlerFilter.java
+++ b/src/main/java/com/nextroom/oescape/security/ExceptionHandlerFilter.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nextroom.oescape.exceptions.CustomException;
 import com.nextroom.oescape.exceptions.ErrorResponse;
 import com.nextroom.oescape.exceptions.StatusCode;
-import com.nextroom.oescape.exceptions.StatusCode;
 
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -50,6 +49,8 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
         objectMapper.getFactory().configure(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature(), true);
 
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(statusCode.getCode().value());
+
         try {
             response.getWriter().write(objectMapper.writeValueAsString(
                     ErrorResponse.builder()


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정

### 반영 브랜치
hotfix/token-200-error → develop

### 작업 사항
- global exception handler 에서 처리하지 않는 security filter 내 exception handler 에서 응답 코드를 설정해주지 않아 발생하는 응답 코드 에러를 수정했습니다.

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
테스트 결과 응답 코드 문제없이 잘 반환합니다.